### PR TITLE
Upping test coverage + tox python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 language: python
 
-python: "3.6"
+python: "3.7"
 
 env:
   global:
@@ -12,9 +12,9 @@ env:
     - TOXENV=py27-django19
     - TOXENV=py27-django110
     - TOXENV=py27-django111
-    - TOXENV=py36-django111
-    - TOXENV=py36-django20
-    - TOXENV=py36-django21
+    - TOXENV=py37-django111
+    - TOXENV=py37-django20
+    - TOXENV=py37-django21
 
 services:
   - postgres

--- a/forkit/tests/models.py
+++ b/forkit/tests/models.py
@@ -77,3 +77,12 @@ class D(ForkableModel):
 
     def __str__(self):
         return u'{0}'.format(self.title)
+
+
+@python_2_unicode_compatible
+class E(ForkableModel):
+    eyedee = models.IntegerField(primary_key=True)
+    title = models.CharField(max_length=50)
+
+    def __str__(self):
+        return u'{0}'.format(self.title)

--- a/forkit/tests/test_utils.py
+++ b/forkit/tests/test_utils.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from forkit import utils, diff
-from forkit.tests.models import Author, Post, Blog, Tag
+from forkit.tests.models import Author, Post, Blog, Tag, E
 
 __all__ = ('UtilsTestCase',)
 
@@ -72,6 +72,30 @@ class UtilsTestCase(TestCase):
 
         self.assertEqual(utils._default_model_fields(tag),
             set(['name', 'post_set']))
+
+    def test_default_fields_includes_id_when_exclude_is_none(self):
+        tag = Tag()
+
+        self.assertEqual(utils._default_model_fields(tag, exclude=None),
+            set(['id', 'name', 'post_set']))
+
+    def test_default_fields_excludes_custom_pk(self):
+        obj = E()
+
+        self.assertEqual(utils._default_model_fields(obj),
+            set(['title']))
+
+    def test_default_fields_includes_custom_pk_when_exclude_is_empty(self):
+        obj = E()
+
+        self.assertEqual(utils._default_model_fields(obj, exclude=None),
+            set(['eyedee', 'title',]))
+
+    def test_default_fields_excludes_custom_pk_when_exclude_includes_pk(self):
+        obj = E()
+
+        self.assertEqual(utils._default_model_fields(obj, exclude=["pk"]),
+            set(['title',]))
 
     def test_deep_default_fields(self):
         author = Author()

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
     ],
     url='https://github.com/Virtualstock/forkit-django/',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-django{18,19,110,111}
-    py36-django{111,20,21}
+    py37-django{111,20,21}
     coverage
 
 


### PR DESCRIPTION
- Upped Tox python 3 runner to python 3.7
- Added a model with custom primary key in test suite
- Covered utils with tests regarding models with custom fields for primary key